### PR TITLE
let olm manage CRDs

### DIFF
--- a/bundle/manifests/spark-helm-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/spark-helm-operator.clusterserviceversion.yaml
@@ -8,6 +8,9 @@ metadata:
           "apiVersion": "apachespark.apache.org/v1alpha1",
           "kind": "Spark",
           "metadata": {
+            "annotations": {
+              "helm.sdk.operatorframework.io/install-disable-crds": "true"
+            },
             "name": "spark-operator"
           },
           "spec": {
@@ -204,7 +207,7 @@ metadata:
     capabilities: Basic Install
     categories: Big Data
     containerImage: quay.io/opdev/airflow-helm-operator:0.0.1
-    createdAt: "2023-07-02T19:16:09Z"
+    createdAt: "2023-07-04T19:53:38Z"
     description: An experimental operator that installs Apache Airflow.
     operatorframework.io/initialization-resource: "{\n  \"apiVersion\": \"apachespark.apache.org/v1alpha1\",\n
       \ \"kind\": \"Spark\",\n  \"metadata\": {\n    \"name\": \"spark-operator\"\n
@@ -239,7 +242,7 @@ metadata:
     operatorframework.io/suggested-namespace: spark-operator
     operators.operatorframework.io/builder: operator-sdk-v1.30.0
     operators.operatorframework.io/project_layout: hybrid.helm.sdk.operatorframework.io/v1-alpha
-  name: spark-helm-operator.v0.0.4
+  name: spark-helm-operator.v0.0.1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -328,12 +331,6 @@ spec:
           verbs:
           - '*'
         - apiGroups:
-          - apiextensions.k8s.io
-          resources:
-          - customresourcedefinitions
-          verbs:
-          - '*'
-        - apiGroups:
           - authentication.k8s.io
           resources:
           - tokenreviews
@@ -414,7 +411,7 @@ spec:
                 - --metrics-bind-address=127.0.0.1:8080
                 - --leader-elect
                 - --leader-election-id=spark-helm-operator
-                image: quay.io/opdev/spark-helm-operator-controller:0.0.4
+                image: quay.io/opdev/spark-helm-operator-controller:0.0.1
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -503,4 +500,4 @@ spec:
   provider:
     name: opdev
     url: opdev.github.io
-  version: 0.0.4
+  version: 0.0.1

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/opdev/spark-helm-operator-controller
-  newTag: 0.0.4
+  newTag: 0.0.1

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -74,10 +74,10 @@ rules:
   - "rolebindings"
   - "roles"
 # hack for crds
-- verbs:
-  - "*"
-  apiGroups:
-  - "apiextensions.k8s.io"
-  resources:
-  - "customresourcedefinitions"
+# - verbs:
+#   - "*"
+#   apiGroups:
+#   - "apiextensions.k8s.io"
+#   resources:
+#   - "customresourcedefinitions"
 #+kubebuilder:scaffold:rules

--- a/config/samples/apachespark_v1alpha1_spark.yaml
+++ b/config/samples/apachespark_v1alpha1_spark.yaml
@@ -2,6 +2,8 @@ apiVersion: apachespark.apache.org/v1alpha1
 kind: Spark
 metadata:
   name: spark-operator
+  annotations:
+    helm.sdk.operatorframework.io/install-disable-crds: true
 spec:
   # Default values copied from <project_dir>/helm-charts/spark-operator/values.yaml
   affinity: {}

--- a/customannotations/annotations.go
+++ b/customannotations/annotations.go
@@ -1,0 +1,42 @@
+package customannotations
+
+import (
+	"strconv"
+
+	hpannotations "github.com/operator-framework/helm-operator-plugins/pkg/annotation"
+	helmclient "github.com/operator-framework/helm-operator-plugins/pkg/client"
+	"helm.sh/helm/v3/pkg/action"
+)
+
+const (
+	defaultDomain             = "helm.sdk.operatorframework.io"
+	defaultInstallDisableCRDs = defaultDomain + "/install-disable-crds"
+)
+
+var (
+	CustomInstallAnnotations = []hpannotations.Install{InstallDisableCRDs{}}
+)
+
+type InstallDisableCRDs struct {
+	CustomName string
+}
+
+var _ hpannotations.Install = &InstallDisableCRDs{}
+
+func (i InstallDisableCRDs) Name() string {
+	if i.CustomName != "" {
+		return i.CustomName
+	}
+	return defaultInstallDisableCRDs
+}
+
+func (i InstallDisableCRDs) InstallOption(val string) helmclient.InstallOption {
+	disableCRDs := false
+	if v, err := strconv.ParseBool(val); err == nil {
+		disableCRDs = v
+	}
+	return func(install *action.Install) error {
+		install.SkipCRDs = disableCRDs
+		return nil
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.19
 
 require (
 	github.com/operator-framework/helm-operator-plugins v0.0.11
+	helm.sh/helm/v3 v3.9.0
 	k8s.io/apimachinery v0.26.0
 	k8s.io/client-go v0.26.0
 	sigs.k8s.io/controller-runtime v0.14.1
@@ -128,7 +129,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	helm.sh/helm/v3 v3.9.0 // indirect
 	k8s.io/api v0.26.0 // indirect
 	k8s.io/apiextensions-apiserver v0.26.0 // indirect
 	k8s.io/apiserver v0.26.0 // indirect

--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/operator-framework/helm-operator-plugins/pkg/annotation"
 	"github.com/operator-framework/helm-operator-plugins/pkg/reconciler"
 	"github.com/operator-framework/helm-operator-plugins/pkg/watches"
+	"github.com/skattoju/spark-helm-operator/customannotations"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
 	ctrlruntime "k8s.io/apimachinery/pkg/runtime"
@@ -123,7 +124,7 @@ func main() {
 			reconciler.SkipDependentWatches(w.WatchDependentResources != nil && !*w.WatchDependentResources),
 			reconciler.WithMaxConcurrentReconciles(maxConcurrentReconciles),
 			reconciler.WithReconcilePeriod(reconcilePeriod),
-			reconciler.WithInstallAnnotations(annotation.DefaultInstallAnnotations...),
+			reconciler.WithInstallAnnotations(customannotations.CustomInstallAnnotations...),
 			reconciler.WithUpgradeAnnotations(annotation.DefaultUpgradeAnnotations...),
 			reconciler.WithUninstallAnnotations(annotation.DefaultUninstallAnnotations...),
 		)


### PR DESCRIPTION
Currently, (as a hack to make this work) we have allowed the (operator)controller service account to 
create CRDs and RBAC in order to deploy an operator that is packaged as a helm chart. Ideally CRDs and RBACs should be managed by OLM and only OLM should have the permissions to create them. This PR proposes to use the --SkipCRDs option when installing the helm chart by setting custom annotations. The CRDs will still be owned by the (operand)controller which is deployed by the (operator)controller. Its not exactly ideal. Not even sure if its slightly less jank since the (operand)controller needs permissions to create RBACs anyway. In the future those can be moved into the bundle as well and the RBAC permissions can be removed from (operator)controllers service account. All in the  name of trying to keep the principle of least privilege while adapting an operator that does not conform to the openshift operator lifecycle manage 
conventions.
